### PR TITLE
Added api data caching to local device.

### DIFF
--- a/App.js
+++ b/App.js
@@ -38,11 +38,12 @@ export default class App extends React.Component {
 
     const skipAPILoad = true;
 
-    let apiData = {};
+    let apiData = null;
 
     if (skipAPILoad) {
       //load sample api data
       apiData = {
+        source: 'sample',
         events: events,
         games: games,
         eventCategories: eventCategories,
@@ -57,10 +58,12 @@ export default class App extends React.Component {
   }
 
   handleAPILoaded (apiData) {
-    this.setState({
-      apiLoaded: true, 
-      apiData: apiData
-    });
+    if (this.state.apiData == null || apiData != null) {
+      this.setState({
+        apiLoaded: true, 
+        apiData: apiData,
+      });
+    }
   }
 
   render() {

--- a/screens/APIScreen.js
+++ b/screens/APIScreen.js
@@ -7,6 +7,7 @@ import {
   View,
   ScrollView,
   Alert,
+  AsyncStorage,
 } from 'react-native';
 import axios from 'axios';
 
@@ -23,34 +24,63 @@ const apiCalls = [
   {key: 'eventCategories', url: 'http://replayfxcalendar.azurewebsites.net/public/categories'},
   {key: 'gameTypes', url: 'http://replayfxcalendar.azurewebsites.net/public/gametypes'},
 
-]
+];
+
+const persistKey = "@ReplayFX:apiData";
 
 export default class APIScreen extends React.Component {
   constructor(props){
     super(props);
 
     this.state = {
-      err: null
+      err: null,
     }
 
     this.debug = false;
-    this.apiData = {};
+    this.apiData = {source: null};
+    this.liveDataLoaded = false;
+
+    this.err = [];
+
+    this._fetchData();
 
     //load the apiData object with the apiCalls keys and a null value
     apiCalls.forEach((obj) => { this.apiData[obj.key] = null; });
 
     this.loadAPIData = this.loadAPIData.bind(this);
     this.handleDataLoaded = this.handleDataLoaded.bind(this);
+    this._fetchData = this._fetchData.bind(this);
+    this.getData = this.getData.bind(this);
   }
 
   handleDataLoaded(apiData) {
     if (apiCalls.every((obj) => this.apiData[obj.key] != null)) {
+      this._persistData(apiData);
+      this.apiData.source = "web";
       this.props.dataLoaded(this.apiData);
+      this.liveDataLoaded = true;
     } else {
       //TODO: handle failed requests - try again? when do we decide to go to local storage?
       //for now, send an empty array back - will have to load sample data
-      this.props.dataLoaded({});
+      this.props.dataLoaded(null);
     }
+  }
+
+  _persistData(apiData) {
+      AsyncStorage.setItem(persistKey, JSON.stringify(apiData));
+  }
+
+  _fetchData() {
+    AsyncStorage.getItem(persistKey)
+      .then((apiData) => {
+        if (apiData && !this.liveDataLoaded) {
+          apiData = JSON.parse(apiData);
+          apiData.source = "local";
+          this.props.dataLoaded(apiData);
+        }
+      }).catch((err) => {
+        //Alert.alert(err);
+      });
   }
 
   componentDidMount()
@@ -62,7 +92,7 @@ export default class APIScreen extends React.Component {
     //axios.all([this.getData('<eventurl>'), this.getData('<categoriesurl>')])
     //axios.all([this.getEventCategories(), this.getEvents(), this.getGameTypes(), this.getGames()])
 
-    //filter array beforehand
+    //filter array beforehand - only call ones that have failed
     filteredCalls = apiCalls.filter((obj) => this.apiData[obj.key] == null);
 
     axios.all(filteredCalls.map((obj) => this.getData(obj.url)))
@@ -82,12 +112,10 @@ export default class APIScreen extends React.Component {
         this.setState({err: errors});
       }
     );
-      
-    //this.handleDataLoaded(this.apiData);
   }
 
   getData(url) {
-    return axios.get(url, {url: url, timeout: 10000}).catch(() => { Alert.alert(url + " failed!"); return null; });
+    return axios.get(url, {timeout: 10000}).catch((reason) => { this.err.push(reason); return null; });
     //return axios.get(url, {url: url, timeout: 10000});
   }
   

--- a/screens/ScheduleScreen.js
+++ b/screens/ScheduleScreen.js
@@ -29,6 +29,10 @@ export default class ScheduleScreen extends React.Component {
     this.PressStar=this.PressStar.bind(this);
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.eventList = nextProps.screenProps.apiData.events;
+  }
+
   PressStar() {
     //Alert.alert('You tapped the button!');
     // if (this.state.filter == 'vendors') {
@@ -76,7 +80,6 @@ export default class ScheduleScreen extends React.Component {
           })
 
         }
-        
       
         
       </ScrollView> 


### PR DESCRIPTION
We can now save the loaded web api data to the phone upon success. When opening the app, if there is local data, we load that immediately and replace it when the web calls come back. This way, if a user was able to get the web calls to load at least once, they will have the data on their phone and can access it without needing to successfully request live data every time the app opens.